### PR TITLE
Complete dev and prod namespaces in K8s

### DIFF
--- a/deploy/postgresql-dev.yaml
+++ b/deploy/postgresql-dev.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  serviceName: "postgres"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:alpine
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: password
+          volumeMounts:
+          - name: postgres-storage
+            mountPath: /var/lib/postgresql/data
+          # resources:
+          #   limits:
+          #     cpu: "0.20"
+          #     memory: "64Mi"
+          #   requests:
+          #     cpu: "0.10"        
+          #     memory: "32Mi"
+      volumes:
+      - name: postgres-storage
+        emptyDir: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: NodePort
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+      nodePort: 31033
+
+---
+# This secret can also be created from the command line using environment variables
+#
+# export DATABASE_URI='postgresql://<place-url-to-database-here>'
+# export POSTGRES_PASSWORD='<place-password-here>'
+#
+# kubectl create secret generic postgres-creds \
+#     --from-literal=password=$POSTGRES_PASSWORD
+#     --from-literal=database_uri=$DATABASE_URI
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-creds
+data:
+  password: cG9zdGdyZXM=
+  database_uri: cG9zdGdyZXNxbDovL3Bvc3RncmVzOnBvc3RncmVzQHBvc3RncmVzOjU0MzIvcG9zdGdyZXM=

--- a/deploy/postgresql-prod.yaml
+++ b/deploy/postgresql-prod.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  serviceName: "postgres"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:alpine
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: password
+          volumeMounts:
+          - name: postgres-storage
+            mountPath: /var/lib/postgresql/data
+          # resources:
+          #   limits:
+          #     cpu: "0.20"
+          #     memory: "64Mi"
+          #   requests:
+          #     cpu: "0.10"        
+          #     memory: "32Mi"
+      volumes:
+      - name: postgres-storage
+        emptyDir: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: NodePort
+  selector:
+    app: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+      nodePort: 31034
+
+---
+# This secret can also be created from the command line using environment variables
+#
+# export DATABASE_URI='postgresql://<place-url-to-database-here>'
+# export POSTGRES_PASSWORD='<place-password-here>'
+#
+# kubectl create secret generic postgres-creds \
+#     --from-literal=password=$POSTGRES_PASSWORD
+#     --from-literal=database_uri=$DATABASE_URI
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-creds
+data:
+  password: cG9zdGdyZXM=
+  database_uri: cG9zdGdyZXNxbDovL3Bvc3RncmVzOnBvc3RncmVzQHBvc3RncmVzOjU0MzIvcG9zdGdyZXM=

--- a/deploy/service-dev.yaml
+++ b/deploy/service-dev.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: customers
+spec:
+  selector:
+    app: customers
+  type: NodePort
+  internalTrafficPolicy: Local
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      nodePort: 31001
+      targetPort: 8080

--- a/deploy/service-prod.yaml
+++ b/deploy/service-prod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: customers
+spec:
+  selector:
+    app: customers
+  type: NodePort
+  internalTrafficPolicy: Local
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      nodePort: 31002
+      targetPort: 8080


### PR DESCRIPTION
Currently using different ```service.yaml``` and ```postgresql.yaml``` files for ```dev``` and ```prod``` namespaces. 
This will be cleaned and streamlined when working on the automated CD pipelines.
Port for ```dev``` is 31001.
Port for ```prod``` is 31002.

Merging this PR will close #51 and #52. 